### PR TITLE
Fix box-name detection on argv

### DIFF
--- a/lib/vagrant/devcommands/runner/command.rb
+++ b/lib/vagrant/devcommands/runner/command.rb
@@ -31,16 +31,20 @@ module VagrantPlugins
         def run_argv
           argv = @argv.dup
 
-          argv.shift if @env.machine_index.include?(argv[0].to_s)
+          argv.shift if argv_has_box_name?
           argv.shift
           argv
         end
 
         def run_box(cmd)
           return cmd.box.to_s if cmd.box
-          return @argv[0].to_s if @env.machine_index.include?(@argv[0].to_s)
+          return @argv[0].to_s if argv_has_box_name?
 
           nil
+        end
+
+        def argv_has_box_name?
+          VagrantPlugins::DevCommands::Util.box_name?(@env, @argv[0].to_s)
         end
 
         def run_script(command, argv)

--- a/lib/vagrant/devcommands/runner/command.rb
+++ b/lib/vagrant/devcommands/runner/command.rb
@@ -3,6 +3,8 @@ module VagrantPlugins
     module Runner
       # Command runner
       class Command
+        UTIL = VagrantPlugins::DevCommands::Util
+
         def initialize(plugin, argv, env, registry)
           @plugin   = plugin
           @argv     = argv
@@ -31,20 +33,18 @@ module VagrantPlugins
         def run_argv
           argv = @argv.dup
 
-          argv.shift if argv_has_box_name?
+          argv.shift if UTIL.machine_name?(argv[0].to_s, @env.machine_index)
           argv.shift
           argv
         end
 
         def run_box(cmd)
-          return cmd.box.to_s if cmd.box
-          return @argv[0].to_s if argv_has_box_name?
+          box = nil
+          box = cmd.box.to_s if cmd.box
+          box = @argv[0] if UTIL.machine_name?(@argv[0].to_s,
+                                               @env.machine_index)
 
-          nil
-        end
-
-        def argv_has_box_name?
-          VagrantPlugins::DevCommands::Util.box_name?(@env, @argv[0].to_s)
+          box
         end
 
         def run_script(command, argv)

--- a/lib/vagrant/devcommands/runner/internal_command.rb
+++ b/lib/vagrant/devcommands/runner/internal_command.rb
@@ -35,9 +35,13 @@ module VagrantPlugins
         def run_argv
           argv = @argv.dup
 
-          argv.shift if @env.machine_index.include?(argv[0].to_s)
+          argv.shift if argv_has_box_name?
           argv.shift
           argv
+        end
+
+        def argv_has_box_name?
+          VagrantPlugins::DevCommands::Util.box_name?(@env, @argv[0].to_s)
         end
       end
     end

--- a/lib/vagrant/devcommands/runner/internal_command.rb
+++ b/lib/vagrant/devcommands/runner/internal_command.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
         NAMESPACE_CMD   = VagrantPlugins::DevCommands::InternalCommand
         NAMESPACE_MODEL = VagrantPlugins::DevCommands::Model
         NAMESPACE_SPEC  = VagrantPlugins::DevCommands::InternalSpec
+        UTIL            = VagrantPlugins::DevCommands::Util
 
         COMMANDS = {
           'help'    => NAMESPACE_MODEL::Command.new(NAMESPACE_SPEC::HELP),
@@ -35,13 +36,9 @@ module VagrantPlugins
         def run_argv
           argv = @argv.dup
 
-          argv.shift if argv_has_box_name?
+          argv.shift if UTIL.machine_name?(argv[0].to_s, @env.machine_index)
           argv.shift
           argv
-        end
-
-        def argv_has_box_name?
-          VagrantPlugins::DevCommands::Util.box_name?(@env, @argv[0].to_s)
         end
       end
     end

--- a/lib/vagrant/devcommands/util.rb
+++ b/lib/vagrant/devcommands/util.rb
@@ -6,9 +6,13 @@ module VagrantPlugins
         return nil if argv.empty?
 
         command = argv[0].to_s
-        command = argv[1].to_s if env.machine_index.include?(command)
+        command = argv[1].to_s if box_name?(env, command)
 
         command
+      end
+
+      def self.box_name?(env, box_name)
+        env.machine_index.any? { |machine| machine.name == box_name }
       end
 
       def self.collect_flags(flags)

--- a/lib/vagrant/devcommands/util.rb
+++ b/lib/vagrant/devcommands/util.rb
@@ -6,13 +6,9 @@ module VagrantPlugins
         return nil if argv.empty?
 
         command = argv[0].to_s
-        command = argv[1].to_s if box_name?(env, command)
+        command = argv[1].to_s if machine_name?(command, env.machine_index)
 
         command
-      end
-
-      def self.box_name?(env, box_name)
-        env.machine_index.any? { |machine| machine.name == box_name }
       end
 
       def self.collect_flags(flags)
@@ -31,6 +27,10 @@ module VagrantPlugins
         params.collect do |key, opts|
           "[--#{key}=<#{key}>]" if opts[:optional]
         end
+      end
+
+      def self.machine_name?(name, machine_index)
+        machine_index.any? { |machine| name == machine.name }
       end
 
       def self.max_pad(items_list)


### PR DESCRIPTION
Hi Marc,

according to the README file something like `vagrant run your_box your_command` should work in a multi-vm environment. However "your_box" is expected to be a box uuid in that case, which is kindof cumbersome ...

this is due to checks like

```ruby
command = argv[1].to_s if env.machine_index.include?(command)
```

... where `Vagrant::MachineIndex::include?` takes a UUID (meanwhile?). Maybe some API change somewhen, but haven't checked.

This patch switches behaviour to expect box names instead of UUIDs.
For me this is ok but YMMV, let me know if you'd like it to be changed to support both UUID and name.