### PR TITLE
Allow Array as :argv of chain command

### DIFF
--- a/lib/vagrant/devcommands/runner/chain.rb
+++ b/lib/vagrant/devcommands/runner/chain.rb
@@ -31,7 +31,11 @@ module VagrantPlugins
         def argv_for(command_def)
           return @argv unless command_def.key?(:argv)
 
-          @argv + command_def[:argv].split
+          if command_def[:argv].is_a? String
+            @argv + command_def[:argv].split
+          else
+            @argv + command_def[:argv]
+          end
         end
 
         def runnable_for(command_def)

--- a/lib/vagrant/devcommands/runner/chain.rb
+++ b/lib/vagrant/devcommands/runner/chain.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
         def argv_for(command_def)
           return @argv unless command_def.key?(:argv)
 
-          if command_def[:argv].is_a? String
+          if command_def[:argv].is_a?(String)
             @argv + command_def[:argv].split
           else
             @argv + command_def[:argv]


### PR DESCRIPTION
Given a `Commandfile` like this

```ruby
command 'configure',
  description: 'executes "configure" to prepare build',
  parameters: {
    cxxflags: { default: "-ggdb -Wall -Wno-write-strings" },
    ldflags: { default: "-ggdb" },
  },
  script:  ...
```

if I'd like to create a chain "coverage" and set parameter `cxxflags` to `-O0 --coverage` and `ldflags` to `--coverage`, ... coming from a shell background I intuitivly tried to do this (and after all `vagrant run v8-5.8 configure --cxxflags="-O0 --coverage" --ldflags="--coverage"` on a shell prompt works):

```ruby
chain 'coverage',
  commands: [
    { command: 'phpize' },
    { command: 'configure', argv: '--cxxflags="-O0 --coverage" --ldflags="--coverage"' },
    { command: 'clean' },
    { command: 'build' },
    { command: 'test' },
    { command: 'coverage_report' },
  ]
```

... but this *fails*.

The reason for this is that `argv` is simply `String.split` without a parameter (hence space). So it splits the argv to `[ '--cxxflags="-O0', '--coverage"', '--ldflags="--coverage"' ]` ... which is obviously wrong.

Since I didn't want to add quotes and escape string parsing I introduced array syntax like this

```ruby
chain 'coverage',
  commands: [
    { command: 'phpize' },
    { command: 'configure', argv: ['--cxxflags=-O0 --coverage', '--ldflags=--coverage'] },
    { command: 'clean' },
    { command: 'build' },
    { command: 'test' },
    { command: 'coverage_report' },
  ]
```